### PR TITLE
Update volume mappings to make future versions of docker happy

### DIFF
--- a/cloudera/cdh5/docker-compose.yml
+++ b/cloudera/cdh5/docker-compose.yml
@@ -19,26 +19,26 @@ hdfsnamenode:
   build: hdfs-namenode
   hostname: hdfs-namenode.dockerdomain
   volumes:
-    - conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
+    - ./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
   dns: 172.17.42.1
 
 yarnresourcemanager:
   build: yarn-resource-manager
   hostname: yarn-resource-manager.dockerdomain
   volumes:
-    - conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
+    - ./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
   dns: 172.17.42.1
 
 mapreducehistory:
   build: mapreduce-history
   hostname: mapreduce-history.dockerdomain
   volumes:
-    - conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
+    - ./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
   dns: 172.17.42.1
 
 clusternode:
   build: cluster-node
   domainname: dockerdomain
   volumes:
-    - conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
+    - ./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
   dns: 172.17.42.1

--- a/hortonworks/hdp2/docker-compose.yml
+++ b/hortonworks/hdp2/docker-compose.yml
@@ -19,26 +19,26 @@ hdfsnamenode:
   build: hdfs-namenode
   hostname: hdfs-namenode.dockerdomain
   volumes:
-    - conf.docker_cluster:/etc/hadoop/conf:ro
+    - ./conf.docker_cluster:/etc/hadoop/conf:ro
   dns: 172.17.42.1
 
 yarnresourcemanager:
   build: yarn-resource-manager
   hostname: yarn-resource-manager.dockerdomain
   volumes:
-    - conf.docker_cluster:/etc/hadoop/conf:ro
+    - ./conf.docker_cluster:/etc/hadoop/conf:ro
   dns: 172.17.42.1
 
 mapreducehistory:
   build: mapreduce-history
   hostname: mapreduce-history.dockerdomain
   volumes:
-    - conf.docker_cluster:/etc/hadoop/conf:ro
+    - ./conf.docker_cluster:/etc/hadoop/conf:ro
   dns: 172.17.42.1
 
 clusternode:
   build: cluster-node
   domainname: dockerdomain
   volumes:
-    - conf.docker_cluster:/etc/hadoop/conf:ro
+    - ./conf.docker_cluster:/etc/hadoop/conf:ro
   dns: 172.17.42.1


### PR DESCRIPTION
When using
`Docker version 1.8.1, build d12ea79`
`docker-compose version: 1.4.0`
`docker-machine version 0.4.1 (HEAD)`

Docker prints the following warning:

```
Warning: the mapping "conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
in the volumes config for service "clusternode" is ambiguous. In a future
version of Docker, it will designate a "named" volume
(see https://github.com/docker/docker/pull/14242).
To prevent unexpected behaviour, change it to
"./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
```

This fixes those warnings
