### PR TITLE
Fixes for docker 1.9, docker-compose 1.5.0

### DIFF
--- a/cloudera/cdh5/docker-compose.yml
+++ b/cloudera/cdh5/docker-compose.yml
@@ -13,42 +13,42 @@ dns:
 zookeeper:
   build: zookeeper
   hostname: zookeeper.dockerdomain
-  dns: 172.17.42.1
+  dns: ["172.17.0.1"]
 
 hdfsnamenode:
   build: hdfs-namenode
   hostname: hdfs-namenode.dockerdomain
   volumes:
     - ./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
-  dns: 172.17.42.1
+  dns: ["172.17.0.1"]
 
 yarnresourcemanager:
   build: yarn-resource-manager
   hostname: yarn-resource-manager.dockerdomain
   volumes:
     - ./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
-  dns: 172.17.42.1
+  dns: ["172.17.0.1"]
 
 mapreducehistory:
   build: mapreduce-history
   hostname: mapreduce-history.dockerdomain
   volumes:
     - ./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
-  dns: 172.17.42.1
+  dns: ["172.17.0.1"]
 
 clusternode:
   build: cluster-node
   domainname: dockerdomain
   volumes:
     - ./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
-  dns: 172.17.42.1
+  dns: ["172.17.0.1"]
 
 hiveserver:
   build: hive-server
   hostname: hive-server.dockerdomain
   volumes:
     - ./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
-  dns: 172.17.42.1
+  dns: ["172.17.0.1"]
 
 hivemysql:
   image: mysql:latest
@@ -66,7 +66,7 @@ hivemetastore:
     - ./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
   links:
     - hivemysql
-  dns: 172.17.42.1
+  dns: ["172.17.0.1"]
 
 hue:
   build: hue
@@ -74,4 +74,4 @@ hue:
   volumes:
     - ./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
     - ./conf.hue:/etc/hue/conf:ro
-  dns: 172.17.42.1
+  dns: ["172.17.0.1"]

--- a/cloudera/cdh5/docker-compose.yml
+++ b/cloudera/cdh5/docker-compose.yml
@@ -5,7 +5,7 @@ dns:
   environment:
     DNS_DOMAIN: dockerdomain
   volumes:
-    - /var/run/docker.sock:/var/run/docker.sock
+    - "/var/run/docker.sock:/var/run/docker.sock"
   ports:
     - "53:53"
     - "53:53/udp"
@@ -13,45 +13,51 @@ dns:
 zookeeper:
   build: zookeeper
   hostname: zookeeper.dockerdomain
-  dns: ["172.17.0.1"]
+  dns:
+    - "172.17.0.1"
 
 hdfsnamenode:
   build: hdfs-namenode
   hostname: hdfs-namenode.dockerdomain
   volumes:
-    - ./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
-  dns: ["172.17.0.1"]
+    - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
+  dns:
+    - "172.17.0.1"
 
 yarnresourcemanager:
   build: yarn-resource-manager
   hostname: yarn-resource-manager.dockerdomain
   volumes:
-    - ./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
-  dns: ["172.17.0.1"]
+    - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
+  dns:
+    - "172.17.0.1"
 
 mapreducehistory:
   build: mapreduce-history
   hostname: mapreduce-history.dockerdomain
   volumes:
-    - ./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
-  dns: ["172.17.0.1"]
+    - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
+  dns:
+    - "172.17.0.1"
 
 clusternode:
   build: cluster-node
   domainname: dockerdomain
   volumes:
-    - ./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
-  dns: ["172.17.0.1"]
+    - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
+  dns:
+    - "172.17.0.1"
 
 hiveserver:
   build: hive-server
   hostname: hive-server.dockerdomain
   volumes:
-    - ./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
-  dns: ["172.17.0.1"]
+    - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
+  dns:
+    - "172.17.0.1"
 
 hivemysql:
-  image: mysql:latest
+  image: "mysql:latest"
   hostname: mysql-hive-metastore.dockerdomain
   environment:
     MYSQL_ROOT_PASSWORD: floating
@@ -63,15 +69,17 @@ hivemetastore:
   build: hive-metastore
   hostname: hive-metastore.dockerdomain
   volumes:
-    - ./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
+    - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
   links:
     - hivemysql
-  dns: ["172.17.0.1"]
+  dns:
+    - "172.17.0.1"
 
 hue:
   build: hue
   hostname: hue.dockerdomain
   volumes:
-    - ./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
-    - ./conf.hue:/etc/hue/conf:ro
-  dns: ["172.17.0.1"]
+    - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
+    - "./conf.hue:/etc/hue/conf:ro"
+  dns:
+    - "172.17.0.1"

--- a/cloudera/cdh5/utils.yml
+++ b/cloudera/cdh5/utils.yml
@@ -5,4 +5,4 @@ hdfs:
   user: hdfs
   entrypoint:
     - "hdfs"
-  dns: 172.17.42.1
+  dns: ["172.17.0.1"]

--- a/cloudera/cdh5/utils.yml
+++ b/cloudera/cdh5/utils.yml
@@ -1,8 +1,9 @@
 hdfs:
   build: base
   volumes:
-    - ./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro
+    - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
   user: hdfs
   entrypoint:
-    - "hdfs"
-  dns: ["172.17.0.1"]
+    - hdfs
+  dns:
+    - "172.17.0.1"

--- a/hortonworks/hdp2/docker-compose.yml
+++ b/hortonworks/hdp2/docker-compose.yml
@@ -13,32 +13,32 @@ dns:
 zookeeper:
   build: zookeeper
   hostname: zookeeper.dockerdomain
-  dns: 172.17.42.1
+  dns: ["172.17.0.1"]
 
 hdfsnamenode:
   build: hdfs-namenode
   hostname: hdfs-namenode.dockerdomain
   volumes:
     - ./conf.docker_cluster:/etc/hadoop/conf:ro
-  dns: 172.17.42.1
+  dns: ["172.17.0.1"]
 
 yarnresourcemanager:
   build: yarn-resource-manager
   hostname: yarn-resource-manager.dockerdomain
   volumes:
     - ./conf.docker_cluster:/etc/hadoop/conf:ro
-  dns: 172.17.42.1
+  dns: ["172.17.0.1"]
 
 mapreducehistory:
   build: mapreduce-history
   hostname: mapreduce-history.dockerdomain
   volumes:
     - ./conf.docker_cluster:/etc/hadoop/conf:ro
-  dns: 172.17.42.1
+  dns: ["172.17.0.1"]
 
 clusternode:
   build: cluster-node
   domainname: dockerdomain
   volumes:
     - ./conf.docker_cluster:/etc/hadoop/conf:ro
-  dns: 172.17.42.1
+  dns: ["172.17.0.1"]

--- a/hortonworks/hdp2/docker-compose.yml
+++ b/hortonworks/hdp2/docker-compose.yml
@@ -5,7 +5,7 @@ dns:
   environment:
     DNS_DOMAIN: dockerdomain
   volumes:
-    - /var/run/docker.sock:/var/run/docker.sock
+    - "/var/run/docker.sock:/var/run/docker.sock"
   ports:
     - "53:53"
     - "53:53/udp"
@@ -13,32 +13,37 @@ dns:
 zookeeper:
   build: zookeeper
   hostname: zookeeper.dockerdomain
-  dns: ["172.17.0.1"]
+  dns:
+    - "172.17.0.1"
 
 hdfsnamenode:
   build: hdfs-namenode
   hostname: hdfs-namenode.dockerdomain
   volumes:
-    - ./conf.docker_cluster:/etc/hadoop/conf:ro
-  dns: ["172.17.0.1"]
+    - "./conf.docker_cluster:/etc/hadoop/conf:ro"
+  dns:
+    - "172.17.0.1"
 
 yarnresourcemanager:
   build: yarn-resource-manager
   hostname: yarn-resource-manager.dockerdomain
   volumes:
-    - ./conf.docker_cluster:/etc/hadoop/conf:ro
-  dns: ["172.17.0.1"]
+    - "./conf.docker_cluster:/etc/hadoop/conf:ro"
+  dns:
+    - "172.17.0.1"
 
 mapreducehistory:
   build: mapreduce-history
   hostname: mapreduce-history.dockerdomain
   volumes:
-    - ./conf.docker_cluster:/etc/hadoop/conf:ro
-  dns: ["172.17.0.1"]
+    - "./conf.docker_cluster:/etc/hadoop/conf:ro"
+  dns:
+    - "172.17.0.1"
 
 clusternode:
   build: cluster-node
   domainname: dockerdomain
   volumes:
-    - ./conf.docker_cluster:/etc/hadoop/conf:ro
-  dns: ["172.17.0.1"]
+    - "./conf.docker_cluster:/etc/hadoop/conf:ro"
+  dns:
+    - "172.17.0.1"

--- a/hortonworks/hdp2/utils.yml
+++ b/hortonworks/hdp2/utils.yml
@@ -1,8 +1,9 @@
 hdfs:
   build: base
   volumes:
-    - conf.docker_cluster:/etc/hadoop/conf:ro
+    - "conf.docker_cluster:/etc/hadoop/conf:ro"
   user: hdfs
   entrypoint:
-    - "hdfs"
-  dns: ["172.17.0.1"]
+    - hdfs
+  dns:
+    - "172.17.0.1"

--- a/hortonworks/hdp2/utils.yml
+++ b/hortonworks/hdp2/utils.yml
@@ -1,7 +1,7 @@
 hdfs:
   build: base
   volumes:
-    - "conf.docker_cluster:/etc/hadoop/conf:ro"
+    - "./conf.docker_cluster:/etc/hadoop/conf:ro"
   user: hdfs
   entrypoint:
     - hdfs

--- a/hortonworks/hdp2/utils.yml
+++ b/hortonworks/hdp2/utils.yml
@@ -5,4 +5,4 @@ hdfs:
   user: hdfs
   entrypoint:
     - "hdfs"
-  dns: 172.17.42.1
+  dns: ["172.17.0.1"]


### PR DESCRIPTION
The `docker` bridge IP changes in `docker` v1.9
The `docker-compose.yml` parser is a little more strict in 1.5.0 so use cleaner YAML.