### PR TITLE
Updates for compatibility with docker 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,22 @@ docker-compose up -d --no-recreate
 
 ## Networking
 
-Hadoop services typically use [DNS](https://wiki.apache.org/hadoop/UnknownHost) to connect to each other. Docker's inbuilt [networking features](https://docs.docker.com/compose/networking/) are set up for the services to talk to each other.
+Hadoop services typically use [DNS](https://wiki.apache.org/hadoop/UnknownHost) to connect to each other. Docker's inbuilt [networking features](https://docs.docker.com/compose/networking/) are set up for the services to talk to each other. For example, to create the `hdp2-lagoon` network run
 
-The hostnames are pre-configured in the Hadoop XML configuration files in `conf.docker_cluster` and `docker-compose.yml`. All of these hostnames end with `.cd5-default` or `.hdp2-lagoon`.
+```
+docker network create -d bridge \
+  --subnet=172.21.0.0/16 --gateway 172.21.0.1 --ip-range=172.21.0.0/16 \
+  hdp2-lagoon
+```
+
+We could use `docker-compose` to create networks automatically in the future. Currently the tool will generate domain names with an underscore character, which form invalid URIs.
+
+The hostnames are pre-configured in the Hadoop XML configuration files in `conf.docker_cluster/*.xml` and `docker-compose.yml`. All of these hostnames end with `.cd5-lagoon` or `.hdp2-lagoon`.
 
 Another small container running `dnsmasq` that forwards port 53 acts as the DNS for the host.
 
 To connect to the containers from the host machine using these hostnames, you must add DNS and routing table entries to your host.
+
 
 ### OS X
 

--- a/README.md
+++ b/README.md
@@ -37,22 +37,27 @@ docker-compose up -d --no-recreate
 
 ## Networking
 
-Hadoop services typically use [DNS](https://wiki.apache.org/hadoop/UnknownHost) to connect to each other. One of the containers is a DNS container that automatically adds a DNS entry for every running container.
+Hadoop services typically use [DNS](https://wiki.apache.org/hadoop/UnknownHost) to connect to each other. Docker's inbuilt [networking features](https://docs.docker.com/compose/networking/) are leveraged for the services to talk to each other.
 
-The hostnames are pre-configured in the Hadoop XML configuration files in `conf.docker_cluster` and `docker-compose.yml`. All of these hostnames end with `.dockerdomain`.
+The hostnames are pre-configured in the Hadoop XML configuration files in `conf.docker_cluster` and `docker-compose.yml`. All of these hostnames end with `.cd5_default` or `.hdp2_default`.
+
+Another small container running `dnsmasq` that forwards port 53 acts as the DNS for the host.
 
 To connect to the containers from the host machine using these hostnames, you must add DNS and routing table entries to your host.
 
 ### OS X
 
 We use the [resolver(5)](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man5/resolver.5.html) mechanism built into OS X to resolve DNS addresses correctly via the /etc/resolver directory which you may need to create.
+
+The following instructions assume that you are using the cloudera distro. Replace `vdh5_default` with `hdp2_default` if you are using the hortonworks distro.
+
 If you're using [`boot2docker`](http://boot2docker.io/):
 
 ```
 export DOCKER_HOST_IP=$(boot2docker ip)
 
 sudo mkdir /etc/resolver
-echo "nameserver $DOCKER_HOST_IP" | sudo tee /etc/resolver/dockerdomain
+echo "nameserver $DOCKER_HOST_IP" | sudo tee /etc/resolver/cd5_default
 sudo route -n add -net 172.17.0.0 $DOCKER_HOST_IP
 ```
 
@@ -65,7 +70,7 @@ export DOCKER_HOST_IP=$(docker-machine ip $DOCKER_MACHINE_NAME)
 To remove these settings at a later point, run the following:
 
 ```
-sudo rm /etc/resolver/dockerdomain
+sudo rm /etc/resolver/cd5_default
 sudo route -n delete 172.17.0.0
 ```
 
@@ -75,9 +80,9 @@ Visit the Web UIs for the services:
 
 Service | Web UI URL
 --------|-----------
-HDFS Namenode | http://hdfs-namenode.dockerdomain:50070/
-YARN Resource Manager | http://yarn-resource-manager.dockerdomain:8088/
-MapReduce History Server | http://mapreduce-history.dockerdomain:19888/
+HDFS Namenode | http://http://hdfsnamenode.cdh5_default:50070/
+YARN Resource Manager | http://yarnresourcemanager.cdh5_default:8088/
+MapReduce History Server | http://mapreducehistory.cdh5_default:19888/
 
 ## Multiple worker nodes
 

--- a/cloudera/cdh5/cluster-node/start.sh
+++ b/cloudera/cdh5/cluster-node/start.sh
@@ -14,7 +14,7 @@ do
 done
 
 # Wait for resource manager to come alive on its standard port
-until nc -z -w5 yarnresourcemanager 8032
+until nc -z -w5 yarnresourcemanager.cdh5-lagoon 8032
 do
     echo "Waiting for YARN ResourceManager to become available"
     sleep 1

--- a/cloudera/cdh5/cluster-node/start.sh
+++ b/cloudera/cdh5/cluster-node/start.sh
@@ -14,7 +14,7 @@ do
 done
 
 # Wait for resource manager to come alive on its standard port
-until nc -z -w5 yarn-resource-manager.dockerdomain 8032
+until nc -z -w5 yarnresourcemanager 8032
 do
     echo "Waiting for YARN ResourceManager to become available"
     sleep 1

--- a/cloudera/cdh5/cluster-node/start.sh
+++ b/cloudera/cdh5/cluster-node/start.sh
@@ -22,4 +22,4 @@ done
 
 service hadoop-yarn-nodemanager start
 
-tail -f `find /var/log -name *.log -name *.out`
+tail -f `find /var/log -name *.log -or -name *.out`

--- a/cloudera/cdh5/conf.docker_cluster/core-site.xml
+++ b/cloudera/cdh5/conf.docker_cluster/core-site.xml
@@ -21,7 +21,7 @@
   <!-- Required by anyone  -->
   <property>
     <name>fs.defaultFS</name>
-    <value>hdfs://hdfs-namenode.dockerdomain:8020</value>
+    <value>hdfs://hdfsnamenode:8020</value>
   </property>
 
   <!-- Required by YARN & other applications. -->

--- a/cloudera/cdh5/conf.docker_cluster/core-site.xml
+++ b/cloudera/cdh5/conf.docker_cluster/core-site.xml
@@ -21,7 +21,7 @@
   <!-- Required by anyone  -->
   <property>
     <name>fs.defaultFS</name>
-    <value>hdfs://hdfsnamenode:8020</value>
+    <value>hdfs://hdfsnamenode.cdh5-lagoon:8020</value>
   </property>
 
   <!-- Required by YARN & other applications. -->

--- a/cloudera/cdh5/conf.docker_cluster/hdfs-site.xml
+++ b/cloudera/cdh5/conf.docker_cluster/hdfs-site.xml
@@ -33,7 +33,7 @@
   <!-- Set the WebHDFS address -->
   <property>
     <name>dfs.namenode.http-address</name>
-    <value>hdfs-namenode.dockerdomain:50070</value>
+    <value>hdfsnamenode:50070</value>
     <description>
       The address and the base port on which the dfs NameNode Web UI will listen.
     </description>

--- a/cloudera/cdh5/conf.docker_cluster/hdfs-site.xml
+++ b/cloudera/cdh5/conf.docker_cluster/hdfs-site.xml
@@ -33,7 +33,7 @@
   <!-- Set the WebHDFS address -->
   <property>
     <name>dfs.namenode.http-address</name>
-    <value>hdfsnamenode:50070</value>
+    <value>hdfsnamenode.cdh5-lagoon:50070</value>
     <description>
       The address and the base port on which the dfs NameNode Web UI will listen.
     </description>

--- a/cloudera/cdh5/conf.docker_cluster/hive-site.xml
+++ b/cloudera/cdh5/conf.docker_cluster/hive-site.xml
@@ -20,12 +20,12 @@
 <configuration>
   <property>
     <name>hive.metastore.uris</name>
-    <value>thrift://hivemetastore:9083</value>
+    <value>thrift://hivemetastore.cdh5-lagoon:9083</value>
   </property>
 
   <property>
     <name>javax.jdo.option.ConnectionURL</name>
-    <value>jdbc:mysql://hivemysql:3306/metastore</value>
+    <value>jdbc:mysql://hivemysql.cdh5-lagoon:3306/metastore</value>
     <description>the URL of the MySQL database</description>
   </property>
 

--- a/cloudera/cdh5/conf.docker_cluster/hive-site.xml
+++ b/cloudera/cdh5/conf.docker_cluster/hive-site.xml
@@ -20,12 +20,12 @@
 <configuration>
   <property>
     <name>hive.metastore.uris</name>
-    <value>thrift://hive-metastore.dockerdomain:9083</value>
+    <value>thrift://hivemetastore:9083</value>
   </property>
 
   <property>
     <name>javax.jdo.option.ConnectionURL</name>
-    <value>jdbc:mysql://mysql-hive-metastore.dockerdomain:3306/metastore</value>
+    <value>jdbc:mysql://hivemysql:3306/metastore</value>
     <description>the URL of the MySQL database</description>
   </property>
 
@@ -73,6 +73,6 @@
   <property>
     <name>hive.zookeeper.quorum</name>
     <description>Zookeeper quorum used by Hive's Table Lock Manager</description>
-    <value>zookeeper.dockerdomain</value>
+    <value>zookeeper</value>
   </property>
 </configuration>

--- a/cloudera/cdh5/conf.docker_cluster/mapred-site.xml
+++ b/cloudera/cdh5/conf.docker_cluster/mapred-site.xml
@@ -24,11 +24,11 @@
   <!-- YARN + MRv2 requires a MapReduce Job History server -->
   <property>
     <name>mapreduce.jobhistory.address</name>
-    <value>mapreducehistory:10020</value>
+    <value>mapreducehistory.cdh5-lagoon:10020</value>
   </property>
   <property>
     <name>mapreduce.jobhistory.webapp.address</name>
-    <value>mapreducehistory:19888</value>
+    <value>mapreducehistory.cdh5-lagoon:19888</value>
   </property>
 
   <!-- This needs to be created on HDFS to avoid catastrophic consequences. -->

--- a/cloudera/cdh5/conf.docker_cluster/mapred-site.xml
+++ b/cloudera/cdh5/conf.docker_cluster/mapred-site.xml
@@ -24,11 +24,11 @@
   <!-- YARN + MRv2 requires a MapReduce Job History server -->
   <property>
     <name>mapreduce.jobhistory.address</name>
-    <value>mapreduce-history.dockerdomain:10020</value>
+    <value>mapreducehistory:10020</value>
   </property>
   <property>
     <name>mapreduce.jobhistory.webapp.address</name>
-    <value>mapreduce-history.dockerdomain:19888</value>
+    <value>mapreducehistory:19888</value>
   </property>
 
   <!-- This needs to be created on HDFS to avoid catastrophic consequences. -->

--- a/cloudera/cdh5/conf.docker_cluster/yarn-site.xml
+++ b/cloudera/cdh5/conf.docker_cluster/yarn-site.xml
@@ -25,7 +25,7 @@
 
   <property>
     <name>yarn.resourcemanager.hostname</name>
-    <value>yarnresourcemanager</value>
+    <value>yarnresourcemanager.cdh5-lagoon</value>
   </property>
 
   <!-- Filled in by the above property

--- a/cloudera/cdh5/conf.docker_cluster/yarn-site.xml
+++ b/cloudera/cdh5/conf.docker_cluster/yarn-site.xml
@@ -25,7 +25,7 @@
 
   <property>
     <name>yarn.resourcemanager.hostname</name>
-    <value>yarn-resource-manager.dockerdomain</value>
+    <value>yarnresourcemanager</value>
   </property>
 
   <!-- Filled in by the above property

--- a/cloudera/cdh5/conf.hue/hue.ini
+++ b/cloudera/cdh5/conf.hue/hue.ini
@@ -674,7 +674,7 @@
 
     [[[default]]]
       # Enter the filesystem uri
-      fs_defaultfs=hdfs://hdfsnamenode:8020
+      fs_defaultfs=hdfs://hdfsnamenode.cdh5-lagoon:8020
 
       # NameNode logical name.
       ## logical_name=
@@ -682,7 +682,7 @@
       # Use WebHdfs/HttpFs as the communication mechanism.
       # Domain should be the NameNode or HttpFs host.
       # Default port is 14000 for HttpFs.
-      webhdfs_url=http://hdfsnamenode:50070/webhdfs/v1
+      webhdfs_url=http://hdfsnamenode.cdh5-lagoon:50070/webhdfs/v1
 
       # Change this if your HDFS cluster is Kerberos-secured
       ## security_enabled=false
@@ -700,7 +700,7 @@
 
     [[[default]]]
       # Enter the host on which you are running the ResourceManager
-      resourcemanager_host=yarnresourcemanager
+      resourcemanager_host=yarnresourcemanager.cdh5-lagoon
 
       # The port where the ResourceManager IPC listens on
       resourcemanager_port=8032
@@ -715,13 +715,13 @@
       ## security_enabled=false
 
       # URL of the ResourceManager API
-      resourcemanager_api_url=http://yarnresourcemanager:8088
+      resourcemanager_api_url=http://yarnresourcemanager.cdh5-lagoon:8088
 
       # URL of the ProxyServer API
       ## proxy_api_url=http://localhost:8088
 
       # URL of the HistoryServer API
-      history_server_api_url=http://mapreducehistory:19888
+      history_server_api_url=http://mapreducehistory.cdh5-lagoon:19888
 
       # In secure mode (HTTPS), if SSL certificates from from YARN Rest APIs
       # have to be verified against certificate authority
@@ -818,7 +818,7 @@
 
   # Host where HiveServer2 is running.
   # If Kerberos security is enabled, use fully-qualified domain name (FQDN).
-  hive_server_host=hiveserver
+  hive_server_host=hiveserver.cdh5-lagoon
 
   # Port where HiveServer2 Thrift server runs on.
   hive_server_port=10000
@@ -1023,7 +1023,7 @@
     [[[default]]]
       # Zookeeper ensemble. Comma separated list of Host/Port.
       # e.g. localhost:2181,localhost:2182,localhost:2183
-      host_ports=zookeeper:2181
+      host_ports=zookeeper.cdh5-lagoon:2181
 
       # The URL of the REST contrib service (required for znode browsing).
       ## rest_url=http://localhost:9998
@@ -1083,7 +1083,7 @@
 [libzookeeper]
   # ZooKeeper ensemble. Comma separated list of Host/Port.
   # e.g. localhost:2181,localhost:2182,localhost:2183
-  ensemble=zookeeper:2181
+  ensemble=zookeeper.cdh5-lagoon:2181
 
   # Name of Kerberos principal when using security.
   ## principal_name=zookeeper

--- a/cloudera/cdh5/conf.hue/hue.ini
+++ b/cloudera/cdh5/conf.hue/hue.ini
@@ -674,7 +674,7 @@
 
     [[[default]]]
       # Enter the filesystem uri
-      fs_defaultfs=hdfs://hdfs-namenode.dockerdomain:8020
+      fs_defaultfs=hdfs://hdfsnamenode:8020
 
       # NameNode logical name.
       ## logical_name=
@@ -682,7 +682,7 @@
       # Use WebHdfs/HttpFs as the communication mechanism.
       # Domain should be the NameNode or HttpFs host.
       # Default port is 14000 for HttpFs.
-      webhdfs_url=http://hdfs-namenode.dockerdomain:50070/webhdfs/v1
+      webhdfs_url=http://hdfsnamenode:50070/webhdfs/v1
 
       # Change this if your HDFS cluster is Kerberos-secured
       ## security_enabled=false
@@ -700,7 +700,7 @@
 
     [[[default]]]
       # Enter the host on which you are running the ResourceManager
-      resourcemanager_host=yarn-resource-manager.dockerdomain
+      resourcemanager_host=yarnresourcemanager
 
       # The port where the ResourceManager IPC listens on
       resourcemanager_port=8032
@@ -715,13 +715,13 @@
       ## security_enabled=false
 
       # URL of the ResourceManager API
-      resourcemanager_api_url=http://yarn-resource-manager.dockerdomain:8088
+      resourcemanager_api_url=http://yarnresourcemanager:8088
 
       # URL of the ProxyServer API
       ## proxy_api_url=http://localhost:8088
 
       # URL of the HistoryServer API
-      history_server_api_url=http://mapreduce-history.dockerdomain:19888
+      history_server_api_url=http://mapreducehistory:19888
 
       # In secure mode (HTTPS), if SSL certificates from from YARN Rest APIs
       # have to be verified against certificate authority
@@ -818,7 +818,7 @@
 
   # Host where HiveServer2 is running.
   # If Kerberos security is enabled, use fully-qualified domain name (FQDN).
-  hive_server_host=hive-server.dockerdomain
+  hive_server_host=hiveserver
 
   # Port where HiveServer2 Thrift server runs on.
   hive_server_port=10000
@@ -1023,7 +1023,7 @@
     [[[default]]]
       # Zookeeper ensemble. Comma separated list of Host/Port.
       # e.g. localhost:2181,localhost:2182,localhost:2183
-      host_ports=zookeeper.dockerdomain:2181
+      host_ports=zookeeper:2181
 
       # The URL of the REST contrib service (required for znode browsing).
       ## rest_url=http://localhost:9998
@@ -1083,7 +1083,7 @@
 [libzookeeper]
   # ZooKeeper ensemble. Comma separated list of Host/Port.
   # e.g. localhost:2181,localhost:2182,localhost:2183
-  ensemble=zookeeper.dockerdomain:2181
+  ensemble=zookeeper:2181
 
   # Name of Kerberos principal when using security.
   ## principal_name=zookeeper

--- a/cloudera/cdh5/dns/Dockerfile
+++ b/cloudera/cdh5/dns/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:trusty
+MAINTAINER Trifacta, Inc.
+
+RUN apt-get update && apt-get install -y dnsmasq
+
+USER root
+CMD ["dnsmasq", "-d"]

--- a/cloudera/cdh5/dns/Dockerfile
+++ b/cloudera/cdh5/dns/Dockerfile
@@ -4,4 +4,4 @@ MAINTAINER Trifacta, Inc.
 RUN apt-get update && apt-get install -y dnsmasq
 
 USER root
-CMD ["dnsmasq", "-d"]
+CMD ["dnsmasq", "--no-daemon"]

--- a/cloudera/cdh5/docker-compose.yml
+++ b/cloudera/cdh5/docker-compose.yml
@@ -1,85 +1,55 @@
-# Registers all container hostname to ip address mappings
-dns:
-  image: iverberk/docker-spy
-  hostname: dns.dockerdomain
-  environment:
-    DNS_DOMAIN: dockerdomain
-  volumes:
-    - "/var/run/docker.sock:/var/run/docker.sock"
-  ports:
-    - "53:53"
-    - "53:53/udp"
+version: '2'
 
-zookeeper:
-  build: zookeeper
-  hostname: zookeeper.dockerdomain
+services:
   dns:
-    - "172.17.0.1"
+    build: dns
+    ports:
+      - "53:53"
+      - "53:53/udp"
 
-hdfsnamenode:
-  build: hdfs-namenode
-  hostname: hdfs-namenode.dockerdomain
-  volumes:
-    - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
-  dns:
-    - "172.17.0.1"
+  zookeeper:
+    build: zookeeper
 
-yarnresourcemanager:
-  build: yarn-resource-manager
-  hostname: yarn-resource-manager.dockerdomain
-  volumes:
-    - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
-  dns:
-    - "172.17.0.1"
+  hdfsnamenode:
+    build: hdfs-namenode
+    volumes:
+      - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
 
-mapreducehistory:
-  build: mapreduce-history
-  hostname: mapreduce-history.dockerdomain
-  volumes:
-    - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
-  dns:
-    - "172.17.0.1"
+  yarnresourcemanager:
+    build: yarn-resource-manager
+    volumes:
+      - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
 
-clusternode:
-  build: cluster-node
-  domainname: dockerdomain
-  volumes:
-    - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
-  dns:
-    - "172.17.0.1"
+  mapreducehistory:
+    build: mapreduce-history
+    volumes:
+      - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
 
-hiveserver:
-  build: hive-server
-  hostname: hive-server.dockerdomain
-  volumes:
-    - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
-  dns:
-    - "172.17.0.1"
+  clusternode:
+    build: cluster-node
+    volumes:
+      - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
 
-hivemysql:
-  image: "mysql:latest"
-  hostname: mysql-hive-metastore.dockerdomain
-  environment:
-    MYSQL_ROOT_PASSWORD: floating
-    MYSQL_DATABASE: metastore
-    MYSQL_USER: hive
-    MYSQL_PASSWORD: elephants
+  hiveserver:
+    build: hive-server
+    volumes:
+      - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
 
-hivemetastore:
-  build: hive-metastore
-  hostname: hive-metastore.dockerdomain
-  volumes:
-    - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
-  links:
-    - hivemysql
-  dns:
-    - "172.17.0.1"
+  hivemysql:
+    image: "mysql:latest"
+    environment:
+      MYSQL_ROOT_PASSWORD: floating
+      MYSQL_DATABASE: metastore
+      MYSQL_USER: hive
+      MYSQL_PASSWORD: elephants
 
-hue:
-  build: hue
-  hostname: hue.dockerdomain
-  volumes:
-    - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
-    - "./conf.hue:/etc/hue/conf:ro"
-  dns:
-    - "172.17.0.1"
+  hivemetastore:
+    build: hive-metastore
+    volumes:
+      - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
+
+  hue:
+    build: hue
+    volumes:
+      - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
+      - "./conf.hue:/etc/hue/conf:ro"

--- a/cloudera/cdh5/docker-compose.yml
+++ b/cloudera/cdh5/docker-compose.yml
@@ -3,37 +3,53 @@ version: '2'
 services:
   dns:
     build: dns
+    hostname: dns
     ports:
       - "53:53"
       - "53:53/udp"
+    networks:
+      - lagoon
 
   zookeeper:
     build: zookeeper
+    hostname: zookeeper
+    networks:
+      - lagoon
 
   hdfsnamenode:
     build: hdfs-namenode
     volumes:
       - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
+    networks:
+      - lagoon
 
   yarnresourcemanager:
     build: yarn-resource-manager
     volumes:
       - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
+    networks:
+      - lagoon
 
   mapreducehistory:
     build: mapreduce-history
     volumes:
       - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
+    networks:
+      - lagoon
 
   clusternode:
     build: cluster-node
     volumes:
       - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
+    networks:
+      - lagoon
 
   hiveserver:
     build: hive-server
     volumes:
       - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
+    networks:
+      - lagoon
 
   hivemysql:
     image: "mysql:latest"
@@ -42,14 +58,25 @@ services:
       MYSQL_DATABASE: metastore
       MYSQL_USER: hive
       MYSQL_PASSWORD: elephants
+    networks:
+      - lagoon
 
   hivemetastore:
     build: hive-metastore
     volumes:
       - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
+    networks:
+      - lagoon
 
   hue:
     build: hue
     volumes:
       - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
       - "./conf.hue:/etc/hue/conf:ro"
+    networks:
+      - lagoon
+
+networks:
+  lagoon:
+    external:
+      name: cdh5-lagoon

--- a/cloudera/cdh5/hdfs-namenode/conf.skeleton/core-site.xml
+++ b/cloudera/cdh5/hdfs-namenode/conf.skeleton/core-site.xml
@@ -23,6 +23,6 @@
 <configuration>
   <property>
    <name>fs.defaultFS</name>
-   <value>hdfs://hdfsnamenode:8020</value>
+   <value>hdfs://hdfsnamenode.cdh5-lagoon:8020</value>
   </property>
 </configuration>

--- a/cloudera/cdh5/hdfs-namenode/conf.skeleton/core-site.xml
+++ b/cloudera/cdh5/hdfs-namenode/conf.skeleton/core-site.xml
@@ -23,6 +23,6 @@
 <configuration>
   <property>
    <name>fs.defaultFS</name>
-   <value>hdfs://hdfs-namenode.dockerdomain:8020</value>
+   <value>hdfs://hdfsnamenode:8020</value>
   </property>
 </configuration>

--- a/cloudera/cdh5/hdfs-namenode/start.sh
+++ b/cloudera/cdh5/hdfs-namenode/start.sh
@@ -13,4 +13,4 @@ done
 sudo -u hdfs hdfs dfs -mkdir /tmp
 sudo -u hdfs hadoop fs -chmod -R 1777 /tmp
 
-tail -f `find /var/log -name *.log -name *.out`
+tail -f `find /var/log -name *.log -or -name *.out`

--- a/cloudera/cdh5/hive-metastore/start.sh
+++ b/cloudera/cdh5/hive-metastore/start.sh
@@ -18,4 +18,4 @@ done
 
 service hive-metastore start
 
-tail -f `find /var/log -name *.log -name *.out`
+tail -f `find /var/log -name *.log -or -name *.out`

--- a/cloudera/cdh5/hive-server/start.sh
+++ b/cloudera/cdh5/hive-server/start.sh
@@ -10,4 +10,4 @@ done
 service hive-webhcat-server start
 service hive-server2 start
 
-tail -f `find /var/log -name *.log -name *.out`
+tail -f `find /var/log -name *.log -or -name *.out`

--- a/cloudera/cdh5/hue/start.sh
+++ b/cloudera/cdh5/hue/start.sh
@@ -13,4 +13,4 @@ sudo -u hdfs hdfs dfs -chown hue:hadoop /user/hue
 
 service hue start
 
-tail -f `find /var/log -name *.log -name *.out`
+tail -f `find /var/log -name *.log -or -name *.out`

--- a/cloudera/cdh5/mapreduce-history/start.sh
+++ b/cloudera/cdh5/mapreduce-history/start.sh
@@ -8,7 +8,7 @@ do
 done
 
 # Wait for resource manager to come alive on its standard port
-until nc -z -w5 yarnresourcemanager 8032
+until nc -z -w5 yarnresourcemanager.cdh5-lagoon 8032
 do
     echo "Waiting for YARN ResourceManager to become available"
     sleep 1

--- a/cloudera/cdh5/mapreduce-history/start.sh
+++ b/cloudera/cdh5/mapreduce-history/start.sh
@@ -16,4 +16,4 @@ done
 
 service hadoop-mapreduce-historyserver start
 
-tail -f `find /var/log -name *.log -name *.out`
+tail -f `find /var/log -name *.log -or -name *.out`

--- a/cloudera/cdh5/mapreduce-history/start.sh
+++ b/cloudera/cdh5/mapreduce-history/start.sh
@@ -8,7 +8,7 @@ do
 done
 
 # Wait for resource manager to come alive on its standard port
-until nc -z -w5 yarn-resource-manager.dockerdomain 8032
+until nc -z -w5 yarnresourcemanager 8032
 do
     echo "Waiting for YARN ResourceManager to become available"
     sleep 1

--- a/cloudera/cdh5/utils.yml
+++ b/cloudera/cdh5/utils.yml
@@ -1,9 +1,10 @@
-hdfs:
-  build: base
-  volumes:
-    - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
-  user: hdfs
-  entrypoint:
-    - hdfs
-  dns:
-    - "172.17.0.1"
+version: '2'
+
+services:
+  hdfs:
+    build: base
+    volumes:
+      - "./conf.docker_cluster:/etc/hadoop/conf.docker_cluster:ro"
+    user: hdfs
+    entrypoint:
+      - hdfs

--- a/cloudera/cdh5/yarn-resource-manager/start.sh
+++ b/cloudera/cdh5/yarn-resource-manager/start.sh
@@ -19,4 +19,4 @@ sudo -u hdfs hadoop fs -chown yarn:mapred /var/log/hadoop-yarn
 
 service hadoop-yarn-resourcemanager start
 
-tail -f `find /var/log -name *.log -name *.out`
+tail -f `find /var/log -name *.log -or -name *.out`

--- a/cloudera/cdh5/zookeeper/start.sh
+++ b/cloudera/cdh5/zookeeper/start.sh
@@ -2,4 +2,4 @@
 
 service zookeeper-server start
 
-tail -f `find /var/log -name *.log -name *.out`
+tail -f `find /var/log -name *.log -or -name *.out`

--- a/hortonworks/hdp2/conf.docker_cluster/core-site.xml
+++ b/hortonworks/hdp2/conf.docker_cluster/core-site.xml
@@ -21,7 +21,7 @@
   <!-- Required by anyone  -->
   <property>
     <name>fs.defaultFS</name>
-    <value>hdfs://hdfsnamenode:8020</value>
+    <value>hdfs://hdfsnamenode.hdp2-lagoon:8020</value>
   </property>
 
   <!-- Required by YARN & other applications. -->

--- a/hortonworks/hdp2/conf.docker_cluster/core-site.xml
+++ b/hortonworks/hdp2/conf.docker_cluster/core-site.xml
@@ -21,7 +21,7 @@
   <!-- Required by anyone  -->
   <property>
     <name>fs.defaultFS</name>
-    <value>hdfs://hdfs-namenode.dockerdomain:8020</value>
+    <value>hdfs://hdfsnamenode:8020</value>
   </property>
 
   <!-- Required by YARN & other applications. -->

--- a/hortonworks/hdp2/conf.docker_cluster/hdfs-site.xml
+++ b/hortonworks/hdp2/conf.docker_cluster/hdfs-site.xml
@@ -33,7 +33,7 @@
   <!-- Set the WebHDFS address -->
   <property>
     <name>dfs.namenode.http-address</name>
-    <value>hdfs-namenode.dockerdomain:50070</value>
+    <value>hdfsnamenode:50070</value>
     <description>
       The address and the base port on which the dfs NameNode Web UI will listen.
     </description>

--- a/hortonworks/hdp2/conf.docker_cluster/hdfs-site.xml
+++ b/hortonworks/hdp2/conf.docker_cluster/hdfs-site.xml
@@ -33,7 +33,7 @@
   <!-- Set the WebHDFS address -->
   <property>
     <name>dfs.namenode.http-address</name>
-    <value>hdfsnamenode:50070</value>
+    <value>hdfsnamenode.hdp2-lagoon:50070</value>
     <description>
       The address and the base port on which the dfs NameNode Web UI will listen.
     </description>

--- a/hortonworks/hdp2/conf.docker_cluster/mapred-site.xml
+++ b/hortonworks/hdp2/conf.docker_cluster/mapred-site.xml
@@ -24,11 +24,11 @@
   <!-- YARN + MRv2 requires a MapReduce Job History server -->
   <property>
     <name>mapreduce.jobhistory.address</name>
-    <value>mapreducehistory:10020</value>
+    <value>mapreducehistory.hdp2-lagoon:10020</value>
   </property>
   <property>
     <name>mapreduce.jobhistory.webapp.address</name>
-    <value>mapreducehistory:19888</value>
+    <value>mapreducehistory.hdp2-lagoon:19888</value>
   </property>
 
   <!-- This needs to be created on HDFS to avoid catastrophic consequences. -->

--- a/hortonworks/hdp2/conf.docker_cluster/mapred-site.xml
+++ b/hortonworks/hdp2/conf.docker_cluster/mapred-site.xml
@@ -24,11 +24,11 @@
   <!-- YARN + MRv2 requires a MapReduce Job History server -->
   <property>
     <name>mapreduce.jobhistory.address</name>
-    <value>mapreduce-history.dockerdomain:10020</value>
+    <value>mapreducehistory:10020</value>
   </property>
   <property>
     <name>mapreduce.jobhistory.webapp.address</name>
-    <value>mapreduce-history.dockerdomain:19888</value>
+    <value>mapreducehistory:19888</value>
   </property>
 
   <!-- This needs to be created on HDFS to avoid catastrophic consequences. -->

--- a/hortonworks/hdp2/conf.docker_cluster/yarn-site.xml
+++ b/hortonworks/hdp2/conf.docker_cluster/yarn-site.xml
@@ -25,7 +25,7 @@
 
   <property>
     <name>yarn.resourcemanager.hostname</name>
-    <value>yarn-resource-manager.dockerdomain</value>
+    <value>yarnresourcemanager</value>
   </property>
 
   <!-- Filled in by the above property

--- a/hortonworks/hdp2/conf.docker_cluster/yarn-site.xml
+++ b/hortonworks/hdp2/conf.docker_cluster/yarn-site.xml
@@ -25,7 +25,7 @@
 
   <property>
     <name>yarn.resourcemanager.hostname</name>
-    <value>yarnresourcemanager</value>
+    <value>yarnresourcemanager.hdp2-lagoon</value>
   </property>
 
   <!-- Filled in by the above property

--- a/hortonworks/hdp2/dns/Dockerfile
+++ b/hortonworks/hdp2/dns/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:trusty
+MAINTAINER Trifacta, Inc.
+
+RUN apt-get update && apt-get install -y dnsmasq
+
+USER root
+CMD ["dnsmasq", "-d"]

--- a/hortonworks/hdp2/dns/Dockerfile
+++ b/hortonworks/hdp2/dns/Dockerfile
@@ -4,4 +4,4 @@ MAINTAINER Trifacta, Inc.
 RUN apt-get update && apt-get install -y dnsmasq
 
 USER root
-CMD ["dnsmasq", "-d"]
+CMD ["dnsmasq", "--no-daemon"]

--- a/hortonworks/hdp2/docker-compose.yml
+++ b/hortonworks/hdp2/docker-compose.yml
@@ -6,26 +6,43 @@ services:
     ports:
       - "53:53"
       - "53:53/udp"
+    networks:
+      - lagoon
 
   zookeeper:
     build: zookeeper
+    networks:
+      - lagoon
 
   hdfsnamenode:
     build: hdfs-namenode
     volumes:
       - "./conf.docker_cluster:/etc/hadoop/conf:ro"
+    networks:
+      - lagoon
 
   yarnresourcemanager:
     build: yarn-resource-manager
     volumes:
       - "./conf.docker_cluster:/etc/hadoop/conf:ro"
+    networks:
+      - lagoon
 
   mapreducehistory:
     build: mapreduce-history
     volumes:
       - "./conf.docker_cluster:/etc/hadoop/conf:ro"
+    networks:
+      - lagoon
 
   clusternode:
     build: cluster-node
     volumes:
       - "./conf.docker_cluster:/etc/hadoop/conf:ro"
+    networks:
+      - lagoon
+
+networks:
+  lagoon:
+    external:
+      name: hdp2-lagoon

--- a/hortonworks/hdp2/docker-compose.yml
+++ b/hortonworks/hdp2/docker-compose.yml
@@ -1,49 +1,31 @@
-# Registers all container hostname to ip address mappings
-dns:
-  image: iverberk/docker-spy
-  hostname: dns.dockerdomain
-  environment:
-    DNS_DOMAIN: dockerdomain
-  volumes:
-    - "/var/run/docker.sock:/var/run/docker.sock"
-  ports:
-    - "53:53"
-    - "53:53/udp"
+version: '2'
 
-zookeeper:
-  build: zookeeper
-  hostname: zookeeper.dockerdomain
+services:
   dns:
-    - "172.17.0.1"
+    build: dns
+    ports:
+      - "53:53"
+      - "53:53/udp"
 
-hdfsnamenode:
-  build: hdfs-namenode
-  hostname: hdfs-namenode.dockerdomain
-  volumes:
-    - "./conf.docker_cluster:/etc/hadoop/conf:ro"
-  dns:
-    - "172.17.0.1"
+  zookeeper:
+    build: zookeeper
 
-yarnresourcemanager:
-  build: yarn-resource-manager
-  hostname: yarn-resource-manager.dockerdomain
-  volumes:
-    - "./conf.docker_cluster:/etc/hadoop/conf:ro"
-  dns:
-    - "172.17.0.1"
+  hdfsnamenode:
+    build: hdfs-namenode
+    volumes:
+      - "./conf.docker_cluster:/etc/hadoop/conf:ro"
 
-mapreducehistory:
-  build: mapreduce-history
-  hostname: mapreduce-history.dockerdomain
-  volumes:
-    - "./conf.docker_cluster:/etc/hadoop/conf:ro"
-  dns:
-    - "172.17.0.1"
+  yarnresourcemanager:
+    build: yarn-resource-manager
+    volumes:
+      - "./conf.docker_cluster:/etc/hadoop/conf:ro"
 
-clusternode:
-  build: cluster-node
-  domainname: dockerdomain
-  volumes:
-    - "./conf.docker_cluster:/etc/hadoop/conf:ro"
-  dns:
-    - "172.17.0.1"
+  mapreducehistory:
+    build: mapreduce-history
+    volumes:
+      - "./conf.docker_cluster:/etc/hadoop/conf:ro"
+
+  clusternode:
+    build: cluster-node
+    volumes:
+      - "./conf.docker_cluster:/etc/hadoop/conf:ro"

--- a/hortonworks/hdp2/hdfs-namenode/conf.skeleton/core-site.xml
+++ b/hortonworks/hdp2/hdfs-namenode/conf.skeleton/core-site.xml
@@ -1,6 +1,6 @@
 <configuration>
   <property>
    <name>fs.defaultFS</name>
-   <value>hdfs://hdfsnamenode:8020</value>
+   <value>hdfs://hdfsnamenode.hdp2-lagoon:8020</value>
   </property>
 </configuration>

--- a/hortonworks/hdp2/hdfs-namenode/conf.skeleton/core-site.xml
+++ b/hortonworks/hdp2/hdfs-namenode/conf.skeleton/core-site.xml
@@ -1,6 +1,6 @@
 <configuration>
   <property>
    <name>fs.defaultFS</name>
-   <value>hdfs://hdfs-namenode.dockerdomain:8020</value>
+   <value>hdfs://hdfsnamenode:8020</value>
   </property>
 </configuration>

--- a/hortonworks/hdp2/mapreduce-history/start.sh
+++ b/hortonworks/hdp2/mapreduce-history/start.sh
@@ -8,7 +8,7 @@ do
 done
 
 # Wait for resource manager to come alive on its standard port
-until nc -z -w5 yarnresourcemanager 8032
+until nc -z -w5 yarnresourcemanager.hdp2-lagoon 8032
 do
     echo "Waiting for YARN ResourceManager to become available"
     sleep 1

--- a/hortonworks/hdp2/mapreduce-history/start.sh
+++ b/hortonworks/hdp2/mapreduce-history/start.sh
@@ -8,7 +8,7 @@ do
 done
 
 # Wait for resource manager to come alive on its standard port
-until nc -z -w5 yarn-resource-manager.dockerdomain 8032
+until nc -z -w5 yarnresourcemanager 8032
 do
     echo "Waiting for YARN ResourceManager to become available"
     sleep 1

--- a/hortonworks/hdp2/utils.yml
+++ b/hortonworks/hdp2/utils.yml
@@ -1,9 +1,10 @@
-hdfs:
-  build: base
-  volumes:
-    - "./conf.docker_cluster:/etc/hadoop/conf:ro"
-  user: hdfs
-  entrypoint:
-    - hdfs
-  dns:
-    - "172.17.0.1"
+version: '2'
+
+services:
+  hdfs:
+    build: base
+    volumes:
+      - "./conf.docker_cluster:/etc/hadoop/conf:ro"
+    user: hdfs
+    entrypoint:
+      - hdfs

--- a/hortonworks/hdp2/zookeeper/files/zoo.cfg
+++ b/hortonworks/hdp2/zookeeper/files/zoo.cfg
@@ -32,6 +32,6 @@ syncLimit=5
 dataDir=/var/lib/zookeeper
 # the port at which the clients will connect
 clientPort=2181
-server.1=zookeeper:2888:3888
+server.1=zookeeper.cdh5-lagoon:2888:3888
 # server.2=TODO-ZKSERVER-HOSTNAME:2888:3888
 # server.3=TODO-ZKSERVER-HOSTNAME:2888:3888

--- a/hortonworks/hdp2/zookeeper/files/zoo.cfg
+++ b/hortonworks/hdp2/zookeeper/files/zoo.cfg
@@ -32,6 +32,6 @@ syncLimit=5
 dataDir=/var/lib/zookeeper
 # the port at which the clients will connect
 clientPort=2181
-server.1=zookeeper.dockerdomain:2888:3888
+server.1=zookeeper:2888:3888
 # server.2=TODO-ZKSERVER-HOSTNAME:2888:3888
 # server.3=TODO-ZKSERVER-HOSTNAME:2888:3888

--- a/ubuntu-plus-java/Dockerfile
+++ b/ubuntu-plus-java/Dockerfile
@@ -1,4 +1,4 @@
-# Installs Oracle's Java 7 & wget on a vanilla Ubuntu 14.04 container
+# Installs Oracle's Java 8 & wget on a vanilla Ubuntu 14.04 container
 
 FROM ubuntu:trusty
 MAINTAINER Trifacta, Inc.
@@ -6,17 +6,17 @@ MAINTAINER Trifacta, Inc.
 RUN apt-get update -y && \
     apt-get install -y software-properties-common wget
 
-# Install Oracle Java 7, as per instructions from:
+# Install Oracle Java 8, as per instructions from:
 # http://www.webupd8.org/2012/01/install-oracle-java-jdk-7-in-ubuntu-via.html
 RUN add-apt-repository -y ppa:webupd8team/java
 
 # Accept the Oracle licence before installing the package
-RUN echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true \
+RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true \
     | /usr/bin/debconf-set-selections
 
 RUN apt-get -y update && \
-    apt-get install -y oracle-java7-installer oracle-java7-set-default
+    apt-get install -y oracle-java8-installer oracle-java8-set-default
 
-RUN update-java-alternatives -s java-7-oracle
+RUN update-java-alternatives -s java-8-oracle
 
-ENV JAVA_HOME=/usr/lib/jvm/java-7-oracle
+ENV JAVA_HOME=/usr/lib/jvm/java-8-oracle

--- a/ubuntu-plus-java/Dockerfile
+++ b/ubuntu-plus-java/Dockerfile
@@ -3,7 +3,8 @@
 FROM ubuntu:trusty
 MAINTAINER Trifacta, Inc.
 
-RUN apt-get install -y software-properties-common wget
+RUN apt-get update -y && \
+    apt-get install -y software-properties-common wget
 
 # Install Oracle Java 7, as per instructions from:
 # http://www.webupd8.org/2012/01/install-oracle-java-jdk-7-in-ubuntu-via.html


### PR DESCRIPTION
- Update to version 2 of the docker-compose syntax
- Leverage the inbuilt networking to enable containers to talk to each other
- Use a container running `dnsmasq` to act as the dns resolver for the host